### PR TITLE
fix: Add system monikor to Job registration and filter store queries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,5 @@ MigrationBackup/
 .idea/*
 
 dist/
+**/*/jobba-sample.db
+**/*/jobba-sample.db-*

--- a/Jobba.Core/Builders/JobbaBuilder.cs
+++ b/Jobba.Core/Builders/JobbaBuilder.cs
@@ -73,7 +73,8 @@ public class JobbaBuilder
             Description = description,
             JobType = typeof(TJob),
             JobParamsType = typeof(TJobParams),
-            JobStateType = typeof(TJobState)
+            JobStateType = typeof(TJobState),
+            SystemMoniker = _systemMoniker
         };
 
         configureRegistration?.Invoke(registration);

--- a/Jobba.Core/Implementations/Repositories/InMemory/InMemoryJobCleanUpStore.cs
+++ b/Jobba.Core/Implementations/Repositories/InMemory/InMemoryJobCleanUpStore.cs
@@ -3,16 +3,17 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Jobba.Core.Interfaces;
 using Jobba.Core.Interfaces.Repositories;
 
 namespace Jobba.Core.Implementations.Repositories.InMemory;
 
-public class InMemoryJobCleanUpStore : IJobCleanUpStore
+public class InMemoryJobCleanUpStore(IJobSystemInfoProvider systemInfoProvider) : IJobCleanUpStore
 {
     public Task CleanUpJobsAsync(TimeSpan duration, CancellationToken cancellationToken)
     {
         var date = DateTimeOffset.UtcNow.Subtract(duration);
-        var filter = RepositoryExpressions.GetCleanUpExpression(date);
+        var filter = RepositoryExpressions.GetCleanUpExpression(systemInfoProvider.GetSystemInfo(), date);
 
         var jobIds = InMemoryJobStoreCache.Jobs.Values
             .Where(filter.Compile())

--- a/Jobba.Core/Implementations/Repositories/InMemory/InMemoryJobListStore.cs
+++ b/Jobba.Core/Implementations/Repositories/InMemory/InMemoryJobListStore.cs
@@ -2,20 +2,23 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Jobba.Core.Interfaces;
 using Jobba.Core.Interfaces.Repositories;
 using Jobba.Core.Models;
 
 namespace Jobba.Core.Implementations.Repositories.InMemory;
 
-public class InMemoryJobListStore : IJobListStore
+public class InMemoryJobListStore(IJobSystemInfoProvider systemInfoProvider) : IJobListStore
 {
+    private readonly JobSystemInfo _systemInfo = systemInfoProvider.GetSystemInfo();
+
     public Task<IEnumerable<JobInfoBase>> GetActiveJobs(CancellationToken cancellationToken)
         => Task.FromResult(InMemoryJobStoreCache.Jobs.Values
-            .Where(RepositoryExpressions.JobsInProgressExpression.Compile())
+            .Where(RepositoryExpressions.JobsInProgressExpression(_systemInfo).Compile())
             .Select(x => x.ToJobInfoBase()));
 
     public Task<IEnumerable<JobInfoBase>> GetJobsToRetry(CancellationToken cancellationToken)
         => Task.FromResult(InMemoryJobStoreCache.Jobs.Values
-            .Where(RepositoryExpressions.JobsInProgressExpression.Compile())
+            .Where(RepositoryExpressions.JobsInProgressExpression(_systemInfo).Compile())
             .Select(x => x.ToJobInfoBase()));
 }

--- a/Jobba.Core/Implementations/Repositories/RepositoryExpressions.cs
+++ b/Jobba.Core/Implementations/Repositories/RepositoryExpressions.cs
@@ -42,7 +42,7 @@ public static class RepositoryExpressions
         JobSystemInfo systemInfo, string jobName)
     {
         Expression<Func<JobRegistration, bool>> filter =
-            x => x.SystemMoniker == systemInfo.SystemMoniker &&
+            x => (x.SystemMoniker == systemInfo.SystemMoniker || x.SystemMoniker == null) &&
                  x.JobName == jobName;
 
         return filter;

--- a/Jobba.Core/Implementations/Repositories/RepositoryExpressions.cs
+++ b/Jobba.Core/Implementations/Repositories/RepositoryExpressions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Linq.Expressions;
+using Jobba.Core.Interfaces;
 using Jobba.Core.Models;
 using Jobba.Core.Models.Entities;
 
@@ -7,17 +8,52 @@ namespace Jobba.Core.Implementations.Repositories;
 
 public static class RepositoryExpressions
 {
-    public static readonly Expression<Func<JobEntity, bool>> JobRetryExpression =
-        x => (x.Status == JobStatus.Faulted || x.Status == JobStatus.ForceCancelled || x.Status == JobStatus.Unknown) &&
-             !x.IsOutOfRetry;
+    public static Expression<Func<JobEntity, bool>> JobRetryExpression(JobSystemInfo systemInfo)
+    {
+        Expression<Func<JobEntity, bool>> filter = x => x.SystemInfo.SystemMoniker == systemInfo.SystemMoniker &&
+                                                        (x.Status == JobStatus.Faulted ||
+                                                         x.Status == JobStatus.ForceCancelled ||
+                                                         x.Status == JobStatus.Unknown) &&
+                                                        !x.IsOutOfRetry;
+        return filter;
+    }
 
-    public static readonly Expression<Func<JobEntity, bool>> JobsInProgressExpression =
-        x => x.Status == JobStatus.InProgress || x.Status == JobStatus.Enqueued;
+    public static Expression<Func<JobEntity, bool>> JobsInProgressExpression(JobSystemInfo systemInfo)
+    {
+        Expression<Func<JobEntity, bool>> filter = x =>
+            x.SystemInfo.SystemMoniker == systemInfo.SystemMoniker &&
+            (x.Status == JobStatus.InProgress || x.Status == JobStatus.Enqueued);
+        return filter;
+    }
 
-    public static Expression<Func<JobEntity, bool>> GetCleanUpExpression(DateTimeOffset date)
+    public static Expression<Func<JobRegistration, bool>> GetCronJobRegistrationsExpression(
+        JobSystemInfo systemInfo)
+    {
+        Expression<Func<JobRegistration, bool>> filter =
+            x => x.CronExpression != null &&
+                 x.CronExpression != "" &&
+                 x.SystemMoniker == systemInfo.SystemMoniker &&
+                 x.IsInactive != true;
+
+        return filter;
+    }
+
+    public static Expression<Func<JobRegistration, bool>> GetJobByNameExpression(
+        JobSystemInfo systemInfo, string jobName)
+    {
+        Expression<Func<JobRegistration, bool>> filter =
+            x => x.SystemMoniker == systemInfo.SystemMoniker &&
+                 x.JobName == jobName;
+
+        return filter;
+    }
+
+    public static Expression<Func<JobEntity, bool>> GetCleanUpExpression(JobSystemInfo systemInfo,
+        DateTimeOffset date)
     {
         Expression<Func<JobEntity, bool>> filter =
-            x => x.Status != JobStatus.Enqueued &&
+            x => x.SystemInfo.SystemMoniker == systemInfo.SystemMoniker &&
+                 x.Status != JobStatus.Enqueued &&
                  x.Status != JobStatus.InProgress &&
                  date.CompareTo(x.LastProgressDate) > 0;
 

--- a/Jobba.Core/Jobba.Core.csproj
+++ b/Jobba.Core/Jobba.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <Version>7.1.0</Version>
+    <Version>7.1.1</Version>
     <LangVersion>latestmajor</LangVersion>
     <Nullable>disable</Nullable>
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>

--- a/Jobba.Core/Models/JobRegistration.cs
+++ b/Jobba.Core/Models/JobRegistration.cs
@@ -19,7 +19,7 @@ public class JobRegistration : IJobbaEntity
     /// <summary>
     /// The Job's Name
     /// </summary>
-    public string JobName { get; set; }
+    public required string JobName { get; set; }
 
     /// <summary>
     /// The type of job to register
@@ -82,6 +82,11 @@ public class JobRegistration : IJobbaEntity
     public bool IsInactive { get; set; }
 
     /// <summary>
+    /// The system moniker the job is associated with.
+    /// </summary>
+    public required string SystemMoniker { get; set; }
+
+    /// <summary>
     /// The time zone id to use for the job. Must be resolvable by <see cref="TimeZoneInfo.FindSystemTimeZoneById"/>.
     /// </summary>
     public string TimeZoneId
@@ -96,7 +101,9 @@ public class JobRegistration : IJobbaEntity
 
     public TimeZoneInfo TimeZoneInfo => _timeZoneInfo ??= TimeZoneInfo.FindSystemTimeZoneById(TimeZoneId ?? "UTC");
 
-    public static JobRegistration FromTypes<TJob, TJobParams, TJobState>(string name,
+    public static JobRegistration FromTypes<TJob, TJobParams, TJobState>(
+        string systemMoniker,
+        string name,
         string description = default,
         string cron = default,
         TJobParams defaultJobParams = default,
@@ -107,6 +114,7 @@ public class JobRegistration : IJobbaEntity
         where TJobParams : IJobParams
         where TJobState : IJobState => new()
         {
+            SystemMoniker = systemMoniker,
             JobName = name,
             JobType = typeof(TJob),
             JobParamsType = typeof(TJobParams),

--- a/Jobba.Cron/Jobba.Cron.csproj
+++ b/Jobba.Cron/Jobba.Cron.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
-    <Version>7.1.0</Version>
+    <Version>7.1.1</Version>
     <LangVersion>latestmajor</LangVersion>
   </PropertyGroup>
 

--- a/Jobba.MassTransit/Jobba.MassTransit.csproj
+++ b/Jobba.MassTransit/Jobba.MassTransit.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
-    <Version>7.1.0</Version>
+    <Version>7.1.1</Version>
     <LangVersion>latestmajor</LangVersion>
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/Jobba.Redis/Jobba.Redis.csproj
+++ b/Jobba.Redis/Jobba.Redis.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
-    <Version>7.1.0</Version>
+    <Version>7.1.1</Version>
     <LangVersion>latestmajor</LangVersion>
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/Jobba.Store.EF.Sql/Jobba.Store.EF.Sql.csproj
+++ b/Jobba.Store.EF.Sql/Jobba.Store.EF.Sql.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>7.1.0</Version>
+    <Version>7.1.1</Version>
     <LangVersion>latestmajor</LangVersion>
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/Jobba.Store.EF.Sql/Migrations/20241126210604_JobRegistrationSystemMoniker.Designer.cs
+++ b/Jobba.Store.EF.Sql/Migrations/20241126210604_JobRegistrationSystemMoniker.Designer.cs
@@ -5,6 +5,7 @@ using Jobba.Store.EF.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -12,9 +13,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Jobba.Store.EF.Sql.Migrations
 {
     [DbContext(typeof(JobbaDbContext))]
-    partial class JobbaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241126210604_JobRegistrationSystemMoniker")]
+    partial class JobRegistrationSystemMoniker
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/Jobba.Store.EF.Sql/Migrations/20241126210604_JobRegistrationSystemMoniker.cs
+++ b/Jobba.Store.EF.Sql/Migrations/20241126210604_JobRegistrationSystemMoniker.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/Jobba.Store.EF.Sql/Migrations/20241126210604_JobRegistrationSystemMoniker.cs
+++ b/Jobba.Store.EF.Sql/Migrations/20241126210604_JobRegistrationSystemMoniker.cs
@@ -1,0 +1,56 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Jobba.Store.EF.Sql.Migrations
+{
+    /// <inheritdoc />
+    public partial class JobRegistrationSystemMoniker : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_JobRegistrations_JobName",
+                schema: "jobba",
+                table: "JobRegistrations");
+
+            migrationBuilder.AddColumn<string>(
+                name: "SystemMoniker",
+                schema: "jobba",
+                table: "JobRegistrations",
+                type: "nvarchar(450)",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_JobRegistrations_JobName_SystemMoniker",
+                schema: "jobba",
+                table: "JobRegistrations",
+                columns: new[] { "JobName", "SystemMoniker" },
+                unique: true,
+                filter: "[JobName] IS NOT NULL AND [SystemMoniker] IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_JobRegistrations_JobName_SystemMoniker",
+                schema: "jobba",
+                table: "JobRegistrations");
+
+            migrationBuilder.DropColumn(
+                name: "SystemMoniker",
+                schema: "jobba",
+                table: "JobRegistrations");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_JobRegistrations_JobName",
+                schema: "jobba",
+                table: "JobRegistrations",
+                column: "JobName",
+                unique: true,
+                filter: "[JobName] IS NOT NULL");
+        }
+    }
+}

--- a/Jobba.Store.EF.Sql/MigrationsContextFactory.cs
+++ b/Jobba.Store.EF.Sql/MigrationsContextFactory.cs
@@ -11,7 +11,7 @@ public class MigrationsContextFactory : IDesignTimeDbContextFactory<JobbaDbConte
     {
         var optionsBuilder = new DbContextOptionsBuilder<JobbaDbContext>();
         optionsBuilder.UsingSqlServer(
-            "Data Source=.;Initial Catalog=jobba-sample;Persist Security Info=False;User ID=sa;Password=;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;Max Pool Size=200;");
+            "Data Source=.;Initial Catalog=jobba-sample;Persist Security Info=False;User ID=sa;Password=Password0#@!;Encrypt=True;TrustServerCertificate=True;Connection Timeout=30;Max Pool Size=200;");
         return new JobbaDbContext(optionsBuilder.Options);
     }
 }

--- a/Jobba.Store.EF.Sqlite/Jobba.Store.EF.Sqlite.csproj
+++ b/Jobba.Store.EF.Sqlite/Jobba.Store.EF.Sqlite.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>7.1.0</Version>
+    <Version>7.1.1</Version>
     <LangVersion>latestmajor</LangVersion>
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/Jobba.Store.EF.Sqlite/Migrations/20241126211015_JobRegistrationSystemMoniker.Designer.cs
+++ b/Jobba.Store.EF.Sqlite/Migrations/20241126211015_JobRegistrationSystemMoniker.Designer.cs
@@ -4,99 +4,97 @@ using System.Collections.Generic;
 using Jobba.Store.EF.DbContexts;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
 
-namespace Jobba.Store.EF.Sql.Migrations
+namespace Jobba.Store.EF.Sqlite.Migrations
 {
     [DbContext(typeof(JobbaDbContext))]
-    partial class JobbaDbContextModelSnapshot : ModelSnapshot
+    [Migration("20241126211015_JobRegistrationSystemMoniker")]
+    partial class JobRegistrationSystemMoniker
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
-            modelBuilder
-                .HasAnnotation("ProductVersion", "8.0.11")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
-
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder);
+            modelBuilder.HasAnnotation("ProductVersion", "8.0.11");
 
             modelBuilder.Entity("Jobba.Core.Models.Entities.JobEntity", b =>
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("CurrentNumberOfTries")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTimeOffset>("EnqueuedTime")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("FaultedReason")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsOutOfRetry")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("JobName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("JobParameters")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("JobParamsTypeName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("JobRegistrationId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("JobState")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("JobStateTypeName")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("JobType")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<TimeSpan>("JobWatchInterval")
-                        .HasColumnType("time");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTimeOffset>("LastProgressDate")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("TEXT");
 
                     b.Property<decimal>("LastProgressPercentage")
                         .HasPrecision(5, 2)
-                        .HasColumnType("decimal(5,2)");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("MaxNumberOfTries")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("Status")
                         .IsRequired()
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.ComplexProperty<Dictionary<string, object>>("SystemInfo", "Jobba.Core.Models.Entities.JobEntity.SystemInfo#JobSystemInfo", b1 =>
                         {
                             b1.IsRequired();
 
                             b1.Property<string>("ComputerName")
-                                .HasColumnType("nvarchar(max)");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("OperatingSystem")
-                                .HasColumnType("nvarchar(max)");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("SystemMoniker")
-                                .HasColumnType("nvarchar(max)");
+                                .HasColumnType("TEXT");
 
                             b1.Property<string>("User")
-                                .HasColumnType("nvarchar(max)");
+                                .HasColumnType("TEXT");
                         });
 
                     b.HasKey("Id");
@@ -112,26 +110,26 @@ namespace Jobba.Store.EF.Sql.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTimeOffset>("Date")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("JobId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<Guid>("JobRegistrationId")
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("JobState")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Message")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<decimal>("Progress")
                         .HasPrecision(5, 2)
-                        .HasColumnType("decimal(5,2)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
@@ -146,58 +144,57 @@ namespace Jobba.Store.EF.Sql.Migrations
                 {
                     b.Property<Guid>("Id")
                         .ValueGeneratedOnAdd()
-                        .HasColumnType("uniqueidentifier");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("CronExpression")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<TimeSpan>("DefaultJobWatchInterval")
-                        .HasColumnType("time");
+                        .HasColumnType("TEXT");
 
                     b.Property<int>("DefaultMaxNumberOfTries")
-                        .HasColumnType("int");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("DefaultParams")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("DefaultState")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("Description")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<bool>("IsInactive")
-                        .HasColumnType("bit");
+                        .HasColumnType("INTEGER");
 
                     b.Property<string>("JobName")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("JobParamsType")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("JobStateType")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("JobType")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTimeOffset?>("NextExecutionDate")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("TEXT");
 
                     b.Property<DateTimeOffset?>("PreviousExecutionDate")
-                        .HasColumnType("datetimeoffset");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("SystemMoniker")
-                        .HasColumnType("nvarchar(450)");
+                        .HasColumnType("TEXT");
 
                     b.Property<string>("TimeZoneId")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
                     b.HasIndex("JobName", "SystemMoniker")
-                        .IsUnique()
-                        .HasFilter("[JobName] IS NOT NULL AND [SystemMoniker] IS NOT NULL");
+                        .IsUnique();
 
                     b.ToTable("JobRegistrations", "jobba");
                 });

--- a/Jobba.Store.EF.Sqlite/Migrations/20241126211015_JobRegistrationSystemMoniker.cs
+++ b/Jobba.Store.EF.Sqlite/Migrations/20241126211015_JobRegistrationSystemMoniker.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+using Microsoft.EntityFrameworkCore.Migrations;
 
 #nullable disable
 

--- a/Jobba.Store.EF.Sqlite/Migrations/20241126211015_JobRegistrationSystemMoniker.cs
+++ b/Jobba.Store.EF.Sqlite/Migrations/20241126211015_JobRegistrationSystemMoniker.cs
@@ -1,0 +1,54 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Jobba.Store.EF.Sqlite.Migrations
+{
+    /// <inheritdoc />
+    public partial class JobRegistrationSystemMoniker : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_JobRegistrations_JobName",
+                schema: "jobba",
+                table: "JobRegistrations");
+
+            migrationBuilder.AddColumn<string>(
+                name: "SystemMoniker",
+                schema: "jobba",
+                table: "JobRegistrations",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_JobRegistrations_JobName_SystemMoniker",
+                schema: "jobba",
+                table: "JobRegistrations",
+                columns: new[] { "JobName", "SystemMoniker" },
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_JobRegistrations_JobName_SystemMoniker",
+                schema: "jobba",
+                table: "JobRegistrations");
+
+            migrationBuilder.DropColumn(
+                name: "SystemMoniker",
+                schema: "jobba",
+                table: "JobRegistrations");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_JobRegistrations_JobName",
+                schema: "jobba",
+                table: "JobRegistrations",
+                column: "JobName",
+                unique: true);
+        }
+    }
+}

--- a/Jobba.Store.EF.Sqlite/Migrations/JobbaDbContextModelSnapshot.cs
+++ b/Jobba.Store.EF.Sqlite/Migrations/JobbaDbContextModelSnapshot.cs
@@ -182,12 +182,15 @@ namespace Jobba.Store.EF.Sqlite.Migrations
                     b.Property<DateTimeOffset?>("PreviousExecutionDate")
                         .HasColumnType("TEXT");
 
+                    b.Property<string>("SystemMoniker")
+                        .HasColumnType("TEXT");
+
                     b.Property<string>("TimeZoneId")
                         .HasColumnType("TEXT");
 
                     b.HasKey("Id");
 
-                    b.HasIndex("JobName")
+                    b.HasIndex("JobName", "SystemMoniker")
                         .IsUnique();
 
                     b.ToTable("JobRegistrations", "jobba");

--- a/Jobba.Store.EF/DbContexts/JobbaDbContext.cs
+++ b/Jobba.Store.EF/DbContexts/JobbaDbContext.cs
@@ -49,7 +49,7 @@ public class JobbaDbContext : DbContext, IJobbaDbContext
         var builder = modelBuilder.Entity<JobRegistration>();
         builder.ToTable("JobRegistrations", JobbaSchema);
 
-        builder.HasIndex(x => x.JobName).IsUnique();
+        builder.HasIndex(x => new { x.JobName, x.SystemMoniker }).IsUnique();
 
         builder.Property(x => x.JobType).HasConversion<EfTypeConverter>();
         builder.Property(x => x.JobParamsType).HasConversion<EfTypeConverter>();

--- a/Jobba.Store.EF/Implementations/JobbaEfCleanUpStore.cs
+++ b/Jobba.Store.EF/Implementations/JobbaEfCleanUpStore.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Jobba.Core.Implementations.Repositories;
+using Jobba.Core.Interfaces;
 using Jobba.Core.Interfaces.Repositories;
 using Jobba.Store.EF.Interfaces;
 using Microsoft.EntityFrameworkCore;
@@ -12,6 +13,7 @@ namespace Jobba.Store.EF.Implementations;
 
 public class JobbaEfCleanUpStore(
     IDbContextProvider dbContextProvider,
+    IJobSystemInfoProvider systemInfoProvider,
     ILogger<JobbaEfCleanUpStore> logger)
     : IJobCleanUpStore
 {
@@ -21,7 +23,7 @@ public class JobbaEfCleanUpStore(
 
         logger.LogDebug("Cleaning up jobs that have a last progress data <= {Date}", date);
 
-        var filter = RepositoryExpressions.GetCleanUpExpression(date);
+        var filter = RepositoryExpressions.GetCleanUpExpression(systemInfoProvider.GetSystemInfo(), date);
 
         var dbContext = await dbContextProvider.GetDbContextAsync(cancellationToken);
         var jobsToDelete = await dbContext.Jobs.Where(filter).ToListAsync(cancellationToken);

--- a/Jobba.Store.EF/Implementations/JobbaEfJobListStore.cs
+++ b/Jobba.Store.EF/Implementations/JobbaEfJobListStore.cs
@@ -5,6 +5,7 @@ using System.Linq.Expressions;
 using System.Threading;
 using System.Threading.Tasks;
 using Jobba.Core.Implementations.Repositories;
+using Jobba.Core.Interfaces;
 using Jobba.Core.Interfaces.Repositories;
 using Jobba.Core.Models;
 using Jobba.Core.Models.Entities;
@@ -13,13 +14,15 @@ using Microsoft.EntityFrameworkCore;
 
 namespace Jobba.Store.EF.Implementations;
 
-public class JobbaEfJobListStore(IDbContextProvider dbContextProvider) : IJobListStore
+public class JobbaEfJobListStore(IDbContextProvider dbContextProvider, IJobSystemInfoProvider systemInfoProvider) : IJobListStore
 {
+    private readonly JobSystemInfo _systemInfo = systemInfoProvider.GetSystemInfo();
+
     public Task<IEnumerable<JobInfoBase>> GetActiveJobs(CancellationToken cancellationToken)
-        => GetJobInfoBases(RepositoryExpressions.JobsInProgressExpression, cancellationToken);
+        => GetJobInfoBases(RepositoryExpressions.JobsInProgressExpression(_systemInfo), cancellationToken);
 
     public Task<IEnumerable<JobInfoBase>> GetJobsToRetry(CancellationToken cancellationToken)
-        => GetJobInfoBases(RepositoryExpressions.JobRetryExpression, cancellationToken);
+        => GetJobInfoBases(RepositoryExpressions.JobRetryExpression(_systemInfo), cancellationToken);
 
     private async Task<IEnumerable<JobInfoBase>> GetJobInfoBases(Expression<Func<JobEntity, bool>> filter,
         CancellationToken cancellationToken)

--- a/Jobba.Store.EF/Jobba.Store.EF.csproj
+++ b/Jobba.Store.EF/Jobba.Store.EF.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <Version>7.1.0</Version>
+    <Version>7.1.1</Version>
     <LangVersion>latestmajor</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/Jobba.Store.Mongo/Jobba.Store.Mongo.csproj
+++ b/Jobba.Store.Mongo/Jobba.Store.Mongo.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
-    <Version>7.1.0</Version>
+    <Version>7.1.1</Version>
     <LangVersion>latestmajor</LangVersion>
     <Nullable>disable</Nullable>
   </PropertyGroup>

--- a/Jobba.Tests/AutoMoqCustomizations/ServiceProviderCustomization.cs
+++ b/Jobba.Tests/AutoMoqCustomizations/ServiceProviderCustomization.cs
@@ -31,7 +31,8 @@ public class ServiceProviderCustomization : ICustomization
                     JobType = typeof(IJob<DefaultJobParams, DefaultJobState>),
                     JobParamsType = typeof(DefaultJobParams),
                     JobStateType = typeof(DefaultJobState),
-                    JobName = "fake job"
+                    JobName = "fake job",
+                    SystemMoniker = "fake system"
                 }
             });
         }

--- a/Jobba.Tests/Core/Implementations/DefaultJobSchedulerTests.cs
+++ b/Jobba.Tests/Core/Implementations/DefaultJobSchedulerTests.cs
@@ -46,12 +46,14 @@ public class DefaultJobSchedulerTests
 
         var registrationStore = fixture.Freeze<Mock<IJobRegistrationStore>>();
         registrationStore.Setup(x => x.GetByJobNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new JobRegistration
+            .ReturnsAsync((string jobName, CancellationToken _) => new JobRegistration
             {
                 Id = Guid.NewGuid(),
                 JobType = typeof(IJob<DefaultJobParams, DefaultJobState>),
                 JobParamsType = typeof(object),
-                JobStateType = typeof(object)
+                JobStateType = typeof(object),
+                SystemMoniker = "Test",
+                JobName = jobName
             });
 
         var request = fixture.Create<JobRequest<DefaultJobParams, DefaultJobState>>();
@@ -121,12 +123,14 @@ public class DefaultJobSchedulerTests
 
         var registrationStore = fixture.Freeze<Mock<IJobRegistrationStore>>();
         registrationStore.Setup(x => x.GetByJobNameAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(new JobRegistration
+            .ReturnsAsync((string jobName, CancellationToken _) => new JobRegistration
             {
                 Id = Guid.NewGuid(),
                 JobType = typeof(IJob<DefaultJobParams, DefaultJobState>),
                 JobParamsType = typeof(object),
-                JobStateType = typeof(object)
+                JobStateType = typeof(object),
+                SystemMoniker = "Test",
+                JobName = jobName
             });
 
         var jobRunner = fixture.Freeze<Mock<IJobRunner>>();

--- a/Jobba.Tests/EF/JobbaDbContextTests.cs
+++ b/Jobba.Tests/EF/JobbaDbContextTests.cs
@@ -46,6 +46,7 @@ public class JobbaDbContextTests
         var jobRegistration = JobRegistration.FromTypes<TestModels.FooJob, TestModels.FooParams, TestModels.FooState>(
             "Test",
             "Test",
+            "Test",
             "0 0 0 1 1 ? 2099",
             new TestModels.FooParams { Baz = "baz" },
             new TestModels.FooState { Bar = "bar" },

--- a/Jobba.Tests/EF/JobbaEfJobProgressStoreTests.cs
+++ b/Jobba.Tests/EF/JobbaEfJobProgressStoreTests.cs
@@ -46,15 +46,9 @@ public class JobbaEfJobProgressStoreTests
 
     private JobRegistration AddRegistration()
     {
-        var jobRegistration = JobRegistration.FromTypes<TestModels.FooJob, TestModels.FooParams, TestModels.FooState>(
-            "Test",
-            "Test",
-            "0 0 0 1 1 ? 2099",
-            new TestModels.FooParams { Baz = "baz" },
-            new TestModels.FooState { Bar = "bar" },
-            false,
-            null);
-        jobRegistration.Id = Guid.NewGuid();
+        var jobRegistration = _fixture.JobRegistrationBuilder()
+            .With(x => x.Id, Guid.NewGuid)
+            .Create();
         _dbContext.JobRegistrations.Add(jobRegistration);
         _dbContext.SaveChanges();
         return jobRegistration;
@@ -62,10 +56,7 @@ public class JobbaEfJobProgressStoreTests
 
     private JobEntity AddJob()
     {
-        var job = _fixture.Build<JobEntity>()
-            .With(x => x.JobRegistrationId, _jobRegistration.Id)
-            .With(x => x.JobParameters, new TestModels.FooParams { Baz = "baz" })
-            .With(x => x.JobState, new TestModels.FooState { Bar = "bar" })
+        var job = _fixture.JobBuilder(_jobRegistration.Id)
             .With(x => x.Status, JobStatus.InProgress)
             .With(x => x.IsOutOfRetry, false)
             .Create();
@@ -77,7 +68,7 @@ public class JobbaEfJobProgressStoreTests
     }
 
     private JobProgress<TestModels.FooState> CreateProgress() =>
-        new JobProgress<TestModels.FooState>
+        new()
         {
             JobId = _job.Id,
             JobRegistrationId = _job.JobRegistrationId,

--- a/Jobba.Tests/EF/JobbaEfJobStoreTests.cs
+++ b/Jobba.Tests/EF/JobbaEfJobStoreTests.cs
@@ -42,15 +42,9 @@ public class JobbaEfJobStoreTests
 
     private JobRegistration AddRegistration()
     {
-        var jobRegistration = JobRegistration.FromTypes<TestModels.FooJob, TestModels.FooParams, TestModels.FooState>(
-            "Test",
-            "Test",
-            "0 0 0 1 1 ? 2099",
-            new TestModels.FooParams { Baz = "baz" },
-            new TestModels.FooState { Bar = "bar" },
-            false,
-            null);
-        jobRegistration.Id = Guid.NewGuid();
+        var jobRegistration = _fixture.JobRegistrationBuilder()
+            .With(x => x.Id, Guid.NewGuid)
+            .Create();
         _dbContext.JobRegistrations.Add(jobRegistration);
         _dbContext.SaveChanges();
         return jobRegistration;
@@ -58,10 +52,7 @@ public class JobbaEfJobStoreTests
 
     private JobEntity AddJob()
     {
-        var job = _fixture.Build<JobEntity>()
-            .With(x => x.JobRegistrationId, _jobRegistration.Id)
-            .With(x => x.JobParameters, new TestModels.FooParams { Baz = "baz" })
-            .With(x => x.JobState, new TestModels.FooState { Bar = "bar" })
+        var job = _fixture.JobBuilder(_jobRegistration.Id)
             .With(x => x.Status, JobStatus.InProgress)
             .With(x => x.IsOutOfRetry, false)
             .Create();
@@ -138,7 +129,7 @@ public class JobbaEfJobStoreTests
 
         //assert
         jobInfo.Should().NotBeNull();
-        jobInfo.CurrentNumberOfTries.Should().Be(2);
+        jobInfo!.CurrentNumberOfTries.Should().Be(2);
     }
 
     [TestMethod]
@@ -191,7 +182,7 @@ public class JobbaEfJobStoreTests
 
         //assert
         jobInfoBase.Should().NotBeNull();
-        jobInfoBase.Id.Should().Be(job.Id);
+        jobInfoBase!.Id.Should().Be(job.Id);
         jobInfoBase.Description.Should().Be(job.Description);
         jobInfoBase.Status.Should().Be(job.Status);
         jobInfoBase.FaultedReason.Should().Be(job.FaultedReason);

--- a/Jobba.Tests/Mongo/JobbaMongoJobListStoreTests.cs
+++ b/Jobba.Tests/Mongo/JobbaMongoJobListStoreTests.cs
@@ -7,6 +7,7 @@ using AutoFixture;
 using AutoFixture.AutoMoq;
 using FluentAssertions;
 using Jobba.Core.Implementations.Repositories;
+using Jobba.Core.Interfaces;
 using Jobba.Core.Models;
 using Jobba.Core.Models.Entities;
 using Jobba.Store.Mongo.Implementations;
@@ -20,23 +21,34 @@ namespace Jobba.Tests.Mongo;
 [TestClass]
 public class JobbaMongoJobListStoreTests
 {
+    private Fixture _fixture;
+    private JobRegistration _jobRegistration;
+    private Mock<IJobbaMongoRepository<JobEntity>> _mockRepo;
+
+    [TestInitialize]
+    public void TestSetup()
+    {
+        _fixture = new Fixture();
+        _fixture.Customize(new AutoMoqCustomization());
+        _jobRegistration = _fixture.JobRegistrationBuilder().Create();
+
+        _fixture.Freeze<Mock<IJobSystemInfoProvider>>().Setup(x => x.GetSystemInfo())
+            .Returns(TestModels.TestSystemInfo);
+        _mockRepo = _fixture.Freeze<Mock<IJobbaMongoRepository<JobEntity>>>();
+        _mockRepo.Setup(x => x.GetAllAsync(
+                It.IsAny<Expression<Func<JobEntity, bool>>>(),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(_fixture.JobBuilder(_jobRegistration.Id).CreateMany(5).ToList)
+            .Verifiable();
+    }
+
     [TestMethod]
     public async Task Jobba_Mongo_Job_List_Store_Should_Get_Active_Jobs()
     {
         //arrange
-        var fixture = new Fixture();
-        fixture.Customize(new AutoMoqCustomization());
-
-        var mockRepo = fixture.Freeze<Mock<IJobbaMongoRepository<JobEntity>>>();
-        mockRepo.Setup(x => x.GetAllAsync(
-                It.IsAny<Expression<Func<JobEntity, bool>>>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(fixture.CreateMany<JobEntity>(5).ToList);
-
-        var listStore = fixture.Create<JobbaMongoJobListStore>();
-        Expression<Func<JobEntity, bool>> expectedExpression =
-            x => x.Status == JobStatus.InProgress || x.Status == JobStatus.Enqueued;
-
+        var listStore = _fixture.Create<JobbaMongoJobListStore>();
+        var expectedExpression =
+            RepositoryExpressions.JobsInProgressExpression(TestModels.TestSystemInfo);
 
         //act
         var activeJobs = await listStore.GetActiveJobs(default);
@@ -44,7 +56,7 @@ public class JobbaMongoJobListStoreTests
         //assert
         activeJobs.Count().Should().Be(5);
 
-        mockRepo.Verify(x => x.GetAllAsync(
+        _mockRepo.Verify(x => x.GetAllAsync(
             It.Is<Expression<Func<JobEntity, bool>>>(exp => Lambda.ExpressionsEqual(exp, expectedExpression)),
             It.IsAny<CancellationToken>()), Times.Once);
     }
@@ -53,17 +65,10 @@ public class JobbaMongoJobListStoreTests
     public async Task Jobba_Mongo_Job_List_Store_Should_Get_Jobs_To_Retry()
     {
         //arrange
-        var fixture = new Fixture();
-        fixture.Customize(new AutoMoqCustomization());
+        var expectedExpression =
+            RepositoryExpressions.JobRetryExpression(TestModels.TestSystemInfo);
 
-        var mockRepo = fixture.Freeze<Mock<IJobbaMongoRepository<JobEntity>>>();
-        mockRepo.Setup(x => x.GetAllAsync(
-                It.IsAny<Expression<Func<JobEntity, bool>>>(),
-                It.IsAny<CancellationToken>()))
-            .ReturnsAsync(fixture.CreateMany<JobEntity>(5).ToList);
-
-        var listStore = fixture.Create<JobbaMongoJobListStore>();
-
+        var listStore = _fixture.Create<JobbaMongoJobListStore>();
 
         //act
         var activeJobs = await listStore.GetJobsToRetry(default);
@@ -71,9 +76,9 @@ public class JobbaMongoJobListStoreTests
         //assert
         activeJobs.Count().Should().Be(5);
 
-        mockRepo.Verify(x => x.GetAllAsync(
+        _mockRepo.Verify(x => x.GetAllAsync(
             It.Is<Expression<Func<JobEntity, bool>>>(exp =>
-                Lambda.ExpressionsEqual(exp, RepositoryExpressions.JobRetryExpression)),
+                Lambda.ExpressionsEqual(exp, expectedExpression)),
             It.IsAny<CancellationToken>()), Times.Once);
     }
 }

--- a/Jobba.Tests/TestExtensions.cs
+++ b/Jobba.Tests/TestExtensions.cs
@@ -6,7 +6,7 @@ using Jobba.Core.Models.Entities;
 
 namespace Jobba.Tests;
 
-public static  class TestExtensions
+public static class TestExtensions
 {
     public static IPostprocessComposer<JobRegistration> JobRegistrationBuilder(this IFixture fixture)
     {

--- a/Jobba.Tests/TestExtensions.cs
+++ b/Jobba.Tests/TestExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using AutoFixture;
+using AutoFixture.Dsl;
+using Jobba.Core.Models;
+using Jobba.Core.Models.Entities;
+
+namespace Jobba.Tests;
+
+public static  class TestExtensions
+{
+    public static IPostprocessComposer<JobRegistration> JobRegistrationBuilder(this IFixture fixture)
+    {
+        return fixture.Build<JobRegistration>()
+            .With(x => x.SystemMoniker, TestModels.TestSystemInfo.SystemMoniker)
+            .With(x => x.JobName, "Test")
+            .With(x => x.Description, "Test")
+            .With(x => x.DefaultParams, new TestModels.FooParams { Baz = "baz" })
+            .With(x => x.DefaultState, new TestModels.FooState { Bar = "bar" })
+            .With(x => x.IsInactive, false)
+            .With(x => x.TimeZoneId, "UTC");
+    }
+
+    public static IPostprocessComposer<JobRegistration> JobCronRegistrationBuilder(this IFixture fixture,
+        string cron = "0 0 0 1 1 ? 2099") => fixture.JobRegistrationBuilder().With(x => x.CronExpression, cron);
+
+    public static IPostprocessComposer<JobEntity> JobBuilder(this IFixture fixture, Guid jobRegistrationId)
+    {
+        return fixture.Build<JobEntity>()
+            .With(x => x.JobRegistrationId, jobRegistrationId)
+            .With(x => x.JobParameters, new TestModels.FooParams { Baz = "baz" })
+            .With(x => x.JobState, new TestModels.FooState { Bar = "bar" })
+            .With(x => x.SystemInfo, TestModels.TestSystemInfo);
+    }
+}

--- a/Jobba.Tests/TestModels.cs
+++ b/Jobba.Tests/TestModels.cs
@@ -9,6 +9,8 @@ namespace Jobba.Tests;
 
 public class TestModels
 {
+    public static readonly JobSystemInfo TestSystemInfo =
+        new JobSystemInfo("TestMoniker", "TestComputerName", "TestUser", "TestOperationSystem");
 
     public class FooState : IJobState
     {
@@ -28,7 +30,8 @@ public class TestModels
 
         public override string JobName => "Jerb";
 
-        protected override Task OnStartAsync(JobStartContext<FooParams, FooState> jobStartContext, CancellationToken cancellationToken)
+        protected override Task OnStartAsync(JobStartContext<FooParams, FooState> jobStartContext,
+            CancellationToken cancellationToken)
             => Task.CompletedTask;
     }
 }


### PR DESCRIPTION
- Add system monikor string to job registration when adding jobs
- When finding job by name with check for monikor match or null monikor in store to allow for migrating data on load
- Update queries to filter by system monikor
- Create EF migrations
- All integration and unit tests passing